### PR TITLE
Docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ composer.phar
 composer.lock
 /vendor/
 .env
+/.idea
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file

--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ $provider = new \League\OAuth2\Client\Provider\GenericProvider([
 ## docker-compose
 
 Run `docker-compose up` in the root directory of this repository to launch a local server.
-The server will be published to port `8080`:
+The server will be published to port `8080` by default:
 
     http://localhost:8080/
     
 The redirect URL will be `http://localhost:8080/callback.php`, which must be
-set in the configuration and within your Xeeo app.
+set in the configuration of this demo application and within your Xero app.
 
 The local port can be changed through the `APP_HTTP_PORT` variable in the
 environment or set in `.env`.

--- a/README.md
+++ b/README.md
@@ -63,13 +63,17 @@ $provider = new \League\OAuth2\Client\Provider\GenericProvider([
 
 ## docker-compose
 
-Run `docker-compose` in the root directory to launch a local server.
-The server will be published to port 8080:
+Run `docker-compose up` in the root directory of this repository to launch a local server.
+The server will be published to port `8080`:
 
     http://localhost:8080/
     
 The redirect URL will be `http://localhost:8080/callback.php`, which must be
 set in the configuration and within your Xeeo app.
+
+The local port can be changed through the `APP_HTTP_PORT` variable in the
+environment or set in `.env`.
+You may want to do this if port `8080` is already in use.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ $provider = new \League\OAuth2\Client\Provider\GenericProvider([
 
 ```
 
+## docker-compose
+
+Run `docker-compose` in the root directory to launch a local server.
+The server will be published to port 8080:
+
+    http://localhost:8080/
+    
+The redirect URL will be `http://localhost:8080/callback.php`, which must be
+set in the configuration and within your Xeeo app.
+
 ## License
 
 This software is published under the [MIT License](http://en.wikipedia.org/wiki/MIT_License).

--- a/disconnect.php
+++ b/disconnect.php
@@ -1,22 +1,23 @@
+<?php
+    require __DIR__ . '/vendor/autoload.php';
+
+    use XeroPHP\Application\PublicApplication;
+    use XeroPHP\Remote\Request;
+    use XeroPHP\Remote\URL;
+    // Start a session for the oauth session storage
+    session_start();
+
+    unset($_SESSION['oauth']['token']);
+    unset($_SESSION['oauth']['token_secret']);
+    $_SESSION['oauth']['expires'] = null;
+
+    header("Location: index.php");
+?>
 <html>
-	<head>
-		<title>My App</title>
-	</head>
-	<body>
-	<?php
-		require __DIR__ . '/vendor/autoload.php';
-
-		use XeroPHP\Application\PublicApplication;
-		use XeroPHP\Remote\Request;
-		use XeroPHP\Remote\URL;
-		// Start a session for the oauth session storage
-		session_start();
-
-		unset($_SESSION['oauth']['token']);
-		unset($_SESSION['oauth']['token_secret']);
-		$_SESSION['oauth']['expires'] = null;
-
-		 header("Location: index.php");
-	?>
-	</body>
+    <head>
+        <title>My App</title>
+    </head>
+    <body>
+        <a href="index.php">Log in again</a>
+    </body>
 </html>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,16 +1,19 @@
-web:
-  image: nginx:latest
-  ports:
-    - "8080:80"
-  volumes:
-    - .:/var/www
-    - ./nginx/conf.d/:/etc/nginx/conf.d/
-  working_dir: /httpdocs
-  links:
-    - php
-php:
-  image: php:7-fpm
-  expose:
-    - 9000
-  volumes:
-    - .:/var/www
+version: "3.1"
+
+services:
+  web:
+    image: nginx:latest
+    ports:
+      - "${APP_HTTP_PORT:-8080}:80"
+    volumes:
+      - .:/var/www
+      - ./nginx/conf.d/:/etc/nginx/conf.d/
+    working_dir: /httpdocs
+    links:
+      - php
+  php:
+    image: php:7-fpm
+    expose:
+      - 9000
+    volumes:
+      - .:/var/www

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+web:
+  image: nginx:latest
+  ports:
+    - "8080:80"
+  volumes:
+    - .:/var/www
+    - ./nginx/conf.d/:/etc/nginx/conf.d/
+  working_dir: /httpdocs
+  links:
+    - php
+php:
+  image: php:7-fpm
+  expose:
+    - 9000
+  volumes:
+    - .:/var/www

--- a/example.php
+++ b/example.php
@@ -134,12 +134,31 @@ $result = $identityApi->deleteConnection($id);
 		}
 	}
 
-/*
-ACCOUNTING APIs
-Following methods demonstrate Xero's 
-Accounting API endpoints
-https://raw.githubusercontent.com/XeroAPI/Xero-OpenAPI/master/accounting-yaml/xero_accounting.yaml 
-*/
+	public function getConnections($identityApi,$returnObj=false)
+	{
+		$str = '';
+
+
+//[Connections:Read]
+		$result = $identityApi->getConnections();
+//[/Connections:Read]
+
+		if ($returnObj) {
+			return $result;
+		} else {
+			$str = $str . "Connected tenants " . array_reduce($result, function ($carry, $item) {#
+					return trim($carry . ' ' . $item->getTenantId() . ' = "'. $item->getTenantName() . '"');
+				}) . '<br>';
+			return $str;
+		}
+	}
+
+	/*
+    ACCOUNTING APIs
+    Following methods demonstrate Xero's
+    Accounting API endpoints
+    https://raw.githubusercontent.com/XeroAPI/Xero-OpenAPI/master/accounting-yaml/xero_accounting.yaml
+    */
    public function getAccount($xeroTenantId,$apiInstance,$returnObj=false)
 	{
 		$str = '';
@@ -405,7 +424,7 @@ $result2 = $apiInstance->getBankTransactions($xeroTenantId, null, $where);
 		$code = $getAccount->getAccounts()[0]->getCode();
 		$accountId = $getAccount->getAccounts()[0]->getAccountId();
 		$lineitem = $this->getLineItem();
-		$lineitems = [];		
+		$lineitems = [];
 		array_push($lineitems, $lineitem);
 
 //[BankTransactions:Create]

--- a/get.php
+++ b/get.php
@@ -141,8 +141,19 @@
 					    echo $action . " action not supported in API";
 				    }
 				break;
-				
-				case "Account":
+
+                case "Connections":
+                    switch($action)
+                    {
+                        case "Read":
+                            echo $ex->getConnections($identityApi);
+                            break;
+                        default:
+                            echo $action . " action not supported in API";
+                    }
+                    break;
+
+                case "Account":
 				    switch($action)
 					{
 				    	case "Create":

--- a/nginx/conf.d/app.conf
+++ b/nginx/conf.d/app.conf
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+    index index.php index.html;
+    server_name localhost;
+    error_log  /var/log/nginx/error.log;
+    access_log /var/log/nginx/access.log;
+    root /var/www;
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass php:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+}

--- a/xero-sdk-ui/xero.js
+++ b/xero-sdk-ui/xero.js
@@ -18,6 +18,7 @@ Handlebars.getTemplate = function(name) {
 var endpoint = [
     {name: "---IDENTITY---",action:[{name: ""}]},
     {name: "Connection",action:[{name: "Delete"}]},
+    {name: "Connections",action:[{name: "Read"}]},
     {name: "---ACCOUNTING---",action:[{name: ""}]},
     {name: "Account",action:[{name: "Create"},{name: "Read"},{name: "Update"},{name: "Delete"},{name: "Archive"},{name: "Attachment"},{name: "AttachmentById"} ]},
     {name: "Accounts",action:[{name: "Read"}]},


### PR DESCRIPTION
This change intrudces a `docker-compose` file for the quickest way to get the demo app up and running. It works well on Windows using WSL2 and PowerShell, and should work on Linux, though I have not treied it.

The "headers cannot be sent" error has been fixed in `disconnect.php` and the `getConnections()` endpoint has been added to the list of supported endpoints.

This demo app woud benefit from tenant connection selection, and scope selection too. Those are features that are relatively new, so I guess this application has not yet caught up. but I can provide another PR if I get those working for my own purposes, if that is helpful.